### PR TITLE
Add Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,6 @@ jobs:
         ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
         TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') tox
     - name: Run lint
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version == '3.10' }}
       run: |
         tox -e lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version:
+        - '3.10'
+        - '3.11'
+        - '3.12'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: requirements/*.txt
+
+    - name: Upgrade packaging tools
+      run: python -m pip install --upgrade pip setuptools virtualenv wheel
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade codecov tox
+
+    - name: Run tox targets for ${{ matrix.python-version }}
+      run: |
+        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
+        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') tox
+    - name: Run lint
+      if: ${{ matrix.python-version == '3.9' }}
+      run: |
+        tox -e lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,29 @@
+[tox]
+envlist =
+    {py310,py311,py312}-django{50,51,-latest},
+    lint
+
+[testenv]
+deps =
+    django50: django>=5.0a,<5.1
+    django51: django>=5.1a,<5.2
+    django-latest: https://github.com/django/django/archive/main.tar.gz
+    -rrequirements/testing.txt
+allowlist_externals = make
+commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs} --cov=flowbite_classes
+ignore_outcome =
+    django-latest: True
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+
+[testenv:lint]
+skip_install = true
+commands =
+    black . --check
+    isort . --check --dif
+    flake8 flowbite_classes tests
+deps =
+    -rrequirements/lint.txt
+
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
This pull request adds C/I testing using GitHub actions and Dependabot file to keep actions updated.

As the library requires at least Django 5.0, I've included test scenarios for published versions and latest / master branch.